### PR TITLE
Enable PerformanceTracing in Development regardless of the Query params

### DIFF
--- a/addon/initializers/ember-perf-timeline.js
+++ b/addon/initializers/ember-perf-timeline.js
@@ -1,5 +1,8 @@
 /* global requirejs */
 import Ember from 'ember';
+import ENV from '../../config/environment';
+
+const IS_DEVELOPMENT = (ENV.environment === 'development');
 
 export function renderComponentTimeString(payload) {
   return `${payload.object} (Rendering: ${payload.initialRender ? 'initial' : 'update' })`;
@@ -43,7 +46,7 @@ function endMark(label) {
 let hasLocation = typeof self !== 'undefined' && typeof self.location === 'object';
 let shouldActivatePerformanceTracing = hasLocation && /[\?\&]_ember-perf-timeline=true/ig.test(self.location.search);
 
-if (shouldActivatePerformanceTracing) {
+if (shouldActivatePerformanceTracing || IS_DEVELOPMENT) {
   HAS_PERFORMANCE_API = detectPerformanceApi();
 
   let EVENT_ID = 0;

--- a/addon/initializers/ember-perf-timeline.js
+++ b/addon/initializers/ember-perf-timeline.js
@@ -1,8 +1,8 @@
 /* global requirejs */
 import Ember from 'ember';
-import ENV from '../../config/environment';
+import ENV_CONFIG from 'ember-get-config';
 
-const IS_DEVELOPMENT = (ENV.environment === 'development');
+const IS_DEVELOPMENT = (ENV_CONFIG.environment === 'development');
 
 export function renderComponentTimeString(payload) {
   return `${payload.object} (Rendering: ${payload.initialRender ? 'initial' : 'update' })`;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
+    "ember-get-config": "0.2.3",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.3.0",
     "ember-source": "^2.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,6 +1069,14 @@ broccoli-debug@^0.6.2:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
+broccoli-file-creator@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz#27f1b25b1b00e7bb7bf3d5d7abed5f4d5388df4d"
+  integrity sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==
+  dependencies:
+    broccoli-plugin "^1.1.0"
+    mkdirp "^0.5.1"
+
 broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.2.4.tgz#409afb94b9a3a6da9fac8134e91e205f40cc7330"
@@ -1226,6 +1234,16 @@ broccoli-plugin@1.1.0:
 broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#bee704a8e42da08cb58e513aaa436efb7f0ef1ee"
+  dependencies:
+    promise-map-series "^0.2.1"
+    quick-temp "^0.1.3"
+    rimraf "^2.3.4"
+    symlink-or-copy "^1.1.8"
+
+broccoli-plugin@^1.1.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz#a26315732fb99ed2d9fb58f12a1e14e986b4fabd"
+  integrity sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==
   dependencies:
     promise-map-series "^0.2.1"
     quick-temp "^0.1.3"
@@ -2188,6 +2206,14 @@ ember-export-application-global@^2.0.0:
   resolved "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
+
+ember-get-config@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.3.tgz#546e77c991792fffde2f6757a5edb0c5dd122c0e"
+  integrity sha1-VG53yZF5L//eL2dXpe2wxd0SLA4=
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^6.3.0"
 
 ember-load-initializers@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Adding ember-get-config to figure out the app environment in the absense of a container